### PR TITLE
refactor: delegate MT5 constant parsing to pdmt5 >= 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,18 @@ MetaTrader 5 REST API
 [![CI/CD](https://github.com/dceoy/mt5api/actions/workflows/ci.yml/badge.svg)](https://github.com/dceoy/mt5api/actions/workflows/ci.yml)
 
 mt5api exposes MT5 market data, account info, trading history, and trading
-operations over HTTP. It uses the [`pdmt5`](https://github.com/dceoy/pdmt5)
-client internally and adds optional API-key auth and JSON/Parquet response
-formatting.
+operations over HTTP. It is a FastAPI/HTTP adapter over
+[`pdmt5`](https://github.com/dceoy/pdmt5), which provides the core MT5 client,
+dataframe/trading primitives, and canonical MT5 constant parsing. mt5api adds
+optional API-key auth and JSON/Parquet response formatting.
 
-The API server must run on Windows. The `MetaTrader5` Python package used by
-`pdmt5` is supported only on Windows, so you must host `mt5api` on a Windows
-machine with a logged-in MetaTrader 5 terminal. HTTP clients can connect from
-any operating system.
+[`mt5cli`](https://github.com/dceoy/mt5cli) is a sibling CLI/batch adapter for
+the same pdmt5 stack; it is not a dependency of mt5api.
+
+The API server must run on Windows. pdmt5 connects through the MetaTrader 5
+Python API, which is supported only on Windows, so you must host `mt5api` on a
+Windows machine with a logged-in MetaTrader 5 terminal. HTTP clients can connect
+from any operating system.
 
 ## Architecture
 
@@ -32,7 +36,7 @@ graph TB
             Formatters --> Middleware
         end
 
-        Deps --> pdmt5["pdmt5<br/>MT5 Client Library"]
+        Deps --> pdmt5["pdmt5<br/>MT5 Client · Constants · Dataframes"]
         pdmt5 --> MT5["MetaTrader 5<br/>Terminal"]
     end
 
@@ -133,9 +137,9 @@ curl -H "X-API-Key: your-secret-api-key" "http://windows-host:8000/symbols?group
 curl -H "X-API-Key: your-secret-api-key" -H "Accept: application/parquet" "http://windows-host:8000/rates/from?symbol=EURUSD&timeframe=TIMEFRAME_M1&date_from=2024-01-01T00:00:00Z&count=100"
 ```
 
-Market-data and calculation endpoints accept MetaTrader 5 constants either by
-official name (`TIMEFRAME_M1`, `COPY_TICKS_ALL`, `ORDER_TYPE_BUY`) or by their
-integer value.
+Market-data and calculation endpoints accept MetaTrader 5 constants by official
+name (`TIMEFRAME_M1`, `COPY_TICKS_ALL`, `ORDER_TYPE_BUY`), short alias (`M1`,
+`ALL`, `BUY`), or integer value.
 
 ## Endpoints
 

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -108,9 +108,9 @@ If `MT5API_ROUTER_PREFIX` is configured, prepend it to each API route below.
 
 ### Market Data
 
-- `timeframe` and `flags` accept either the official MetaTrader 5 constant
-  name (for example `TIMEFRAME_M1`, `COPY_TICKS_ALL`) or the equivalent integer
-  value.
+- `timeframe` and `flags` accept the official MetaTrader 5 constant name (for
+  example `TIMEFRAME_M1`, `COPY_TICKS_ALL`), a short alias (for example `M1`,
+  `ALL`), or the equivalent integer value.
 - `GET /rates/from` (`symbol`, `timeframe`, `date_from`, `count`, `format`)
 - `GET /rates/from-pos` (`symbol`, `timeframe`, `start_pos`, `count`, `format`)
 - `GET /rates/range` (`symbol`, `timeframe`, `date_from`, `date_to`, `format`)
@@ -122,8 +122,9 @@ If `MT5API_ROUTER_PREFIX` is configured, prepend it to each API route below.
 
 ### Calculations
 
-- `action` accepts either the official MetaTrader 5 constant name (for example
-  `ORDER_TYPE_BUY`) or the equivalent integer value.
+- `action` accepts the official MetaTrader 5 constant name (for example
+  `ORDER_TYPE_BUY`), a short alias (for example `BUY`), or the equivalent
+  integer value.
 - `GET /calc/margin` (`action`, `symbol`, `volume`, `price`, `format`) —
   Calculate required margin in account currency
 - `GET /calc/profit` (`action`, `symbol`, `volume`, `price_open`,

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,14 +5,18 @@ trading operations.
 
 ## Overview
 
-mt5api exposes MT5 data and trading operations over HTTP using FastAPI. It
-relies on the underlying MT5 client library for connectivity and adds optional
-authentication and response formatting suitable for analytics
-workflows.
+mt5api is a FastAPI/HTTP adapter over
+[`pdmt5`](https://github.com/dceoy/pdmt5). pdmt5 provides the core MT5 client,
+dataframe/trading primitives, and canonical MT5 constant parsing. mt5api adds
+optional authentication, response formatting, and OpenAPI documentation.
 
-The API server must run on Windows because the `MetaTrader5` Python package is
-Windows-only. Run `mt5api` on a Windows host with MetaTrader 5 installed and
-logged in. API clients can connect from any operating system.
+[`mt5cli`](https://github.com/dceoy/mt5cli) is a sibling CLI/batch adapter for
+the same pdmt5 stack; it is not a dependency of mt5api.
+
+The API server must run on Windows because pdmt5 connects through the MetaTrader
+5 Python API, which is Windows-only. Run `mt5api` on a Windows host with
+MetaTrader 5 installed and logged in. API clients can connect from any operating
+system.
 
 ## Features
 

--- a/mt5api/models.py
+++ b/mt5api/models.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime  # noqa: TC003
 from enum import StrEnum
-from functools import cache, cached_property
-from typing import TYPE_CHECKING, Annotated, Any, LiteralString, Self, TypeAlias, cast
+from typing import Annotated, Any, Self, TypeAlias
 
-from pdmt5.mt5 import Mt5Client
+import pdmt5
 from pydantic import (
     BaseModel,
     BeforeValidator,
@@ -18,23 +16,10 @@ from pydantic import (
     WithJsonSchema,
     model_validator,
 )
-from pydantic_core import PydanticCustomError
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from types import ModuleType
-
-
-class ResponseFormat(StrEnum):
-    """Response format enumeration."""
-
-    JSON = "json"
-    PARQUET = "parquet"
-
 
 _TIMEFRAME_DESCRIPTION = (
     "MetaTrader5 TIMEFRAME constant. Accepts a constant name such as "
-    "TIMEFRAME_M1 or the corresponding integer value."
+    "TIMEFRAME_M1 or the short alias M1, or the corresponding integer value."
 )
 _TIMEFRAME_EXAMPLE_NAMES = (
     "TIMEFRAME_M1",
@@ -49,149 +34,29 @@ _TIMEFRAME_EXAMPLE_NAMES = (
 )
 _COPY_TICKS_DESCRIPTION = (
     "MetaTrader5 COPY_TICKS constant. Accepts COPY_TICKS_INFO, "
-    "COPY_TICKS_TRADE, COPY_TICKS_ALL, or the corresponding integer value."
+    "COPY_TICKS_TRADE, COPY_TICKS_ALL, short aliases such as ALL, "
+    "or the corresponding integer value."
 )
-_COPY_TICKS_NAMES = (
+_COPY_TICKS_EXAMPLE_NAMES = (
     "COPY_TICKS_INFO",
     "COPY_TICKS_TRADE",
     "COPY_TICKS_ALL",
 )
 _ORDER_TYPE_DESCRIPTION = (
     "MetaTrader5 ORDER_TYPE constant. Accepts a constant name such as "
-    "ORDER_TYPE_BUY or the corresponding integer value."
+    "ORDER_TYPE_BUY or the short alias BUY, or the corresponding integer value."
 )
 _ORDER_TYPE_EXAMPLE_NAMES = (
     "ORDER_TYPE_BUY",
     "ORDER_TYPE_SELL",
 )
-_ORDER_TYPE_VALIDATION_DESCRIPTION = "MetaTrader5 ORDER_TYPE constant"
-_TIMEFRAME_VALIDATION_DESCRIPTION = "MetaTrader5 TIMEFRAME constant"
-_COPY_TICKS_VALIDATION_DESCRIPTION = "MetaTrader5 COPY_TICKS constant"
-
-
-@dataclass(frozen=True)
-class Mt5ConstantSpec:
-    """Metadata and cached values for an MT5 constant family."""
-
-    validation_description: str
-    schema_description: str
-    prefix: str = ""
-    names: tuple[str, ...] = ()
-    example_names: tuple[str, ...] = ()
-
-    @cached_property
-    def members(self) -> dict[str, int]:
-        """Return MT5 constant names and values from the pdmt5 MT5 module copy."""
-        mt5 = _get_mt5_module()
-        if self.names:
-            return {name: int(getattr(mt5, name)) for name in self.names}
-        return {
-            name: int(getattr(mt5, name))
-            for name in dir(mt5)
-            if name.startswith(self.prefix) and isinstance(getattr(mt5, name), int)
-        }
-
-    @cached_property
-    def sorted_names(self) -> tuple[str, ...]:
-        """Return sorted MT5 constant names."""
-        return tuple(sorted(self.members))
-
-    @cached_property
-    def sorted_values(self) -> tuple[int, ...]:
-        """Return sorted MT5 constant values."""
-        return tuple(sorted(self.members.values()))
-
-    @cached_property
-    def example_values(self) -> list[int]:
-        """Return MT5 constant value examples."""
-        return [self.members[name] for name in self.example_names]
-
-    @cached_property
-    def example_name_list(self) -> list[str]:
-        """Return MT5 constant name examples."""
-        return list(self.example_names)
-
-
-@cache
-def _get_mt5_module() -> ModuleType:
-    """Return the MetaTrader5 module used by pdmt5."""
-    factory = cast(
-        "Callable[[], ModuleType]", Mt5Client.model_fields["mt5"].default_factory
-    )
-    return factory()
-
-
-_TIMEFRAME_SPEC = Mt5ConstantSpec(
-    validation_description=_TIMEFRAME_VALIDATION_DESCRIPTION,
-    schema_description=_TIMEFRAME_DESCRIPTION,
-    prefix="TIMEFRAME_",
-    example_names=_TIMEFRAME_EXAMPLE_NAMES,
-)
-_COPY_TICKS_SPEC = Mt5ConstantSpec(
-    validation_description=_COPY_TICKS_VALIDATION_DESCRIPTION,
-    schema_description=_COPY_TICKS_DESCRIPTION,
-    names=_COPY_TICKS_NAMES,
-    example_names=_COPY_TICKS_NAMES,
-)
-_ORDER_TYPE_SPEC = Mt5ConstantSpec(
-    validation_description=_ORDER_TYPE_VALIDATION_DESCRIPTION,
-    schema_description=_ORDER_TYPE_DESCRIPTION,
-    prefix="ORDER_TYPE_",
-    example_names=_ORDER_TYPE_EXAMPLE_NAMES,
-)
-
-
-def _parse_mt5_constant(
-    value: object,
-    *,
-    spec: Mt5ConstantSpec,
-) -> int:
-    """Parse an MT5 constant name or integer value.
-
-    Returns:
-        The validated integer constant value.
-
-    Raises:
-        PydanticCustomError: If the value type is not supported.
-        ValueError: If the value is not a supported constant name or integer.
-    """
-    type_error_code = "mt5_constant_type"
-    type_error_template: LiteralString = (
-        "{description} must be specified by constant name or integer value"
-    )
-    type_error_context = {"description": spec.validation_description}
-    type_error_message = type_error_template.format(**type_error_context)
-    if isinstance(value, str):
-        if value in spec.members:
-            return spec.members[value]
-        try:
-            value = int(value)
-        except ValueError as error:
-            raise ValueError(type_error_message) from error
-
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise PydanticCustomError(
-            type_error_code,
-            type_error_template,
-            type_error_context,
-        )
-
-    parsed_value = value
-
-    if parsed_value not in spec.members.values():
-        error_message = (
-            f"Unsupported {spec.validation_description.lower()} value: {parsed_value}"
-        )
-        raise ValueError(error_message)
-
-    return parsed_value
 
 
 def _build_mt5_constant_json_schema(
     *,
     description: str,
-    names: tuple[str, ...],
-    values: tuple[int, ...],
+    names: tuple[str, ...] | list[str],
+    values: tuple[int, ...] | list[int],
     examples: list[str],
 ) -> dict[str, Any]:
     """Build a JSON schema for a name-or-integer MT5 constant parameter.
@@ -210,43 +75,43 @@ def _build_mt5_constant_json_schema(
 
 
 def get_mt5_timeframe_values() -> tuple[int, ...]:
-    """Return all available MT5 timeframe values from the pdmt5 MT5 module copy."""
-    return _TIMEFRAME_SPEC.sorted_values
+    """Return all available MT5 timeframe values from pdmt5."""
+    return tuple(pdmt5.list_timeframe_values())
 
 
 def get_mt5_timeframe_names() -> tuple[str, ...]:
-    """Return all available MT5 timeframe names from the pdmt5 MT5 module copy."""
-    return _TIMEFRAME_SPEC.sorted_names
+    """Return all available MT5 timeframe names from pdmt5."""
+    return tuple(pdmt5.list_timeframe_names())
 
 
 def get_mt5_timeframe_examples() -> list[int]:
-    """Return common MT5 timeframe examples from the pdmt5 MT5 module copy."""
-    return _TIMEFRAME_SPEC.example_values
+    """Return common MT5 timeframe examples from pdmt5."""
+    return [pdmt5.TIMEFRAME_MAP[name] for name in _TIMEFRAME_EXAMPLE_NAMES]
 
 
 def get_mt5_timeframe_example_names() -> list[str]:
     """Return common MT5 timeframe example names."""
-    return _TIMEFRAME_SPEC.example_name_list
+    return list(_TIMEFRAME_EXAMPLE_NAMES)
 
 
 def get_mt5_copy_ticks_values() -> tuple[int, ...]:
-    """Return all MT5 COPY_TICKS values from the pdmt5 MT5 module copy."""
-    return _COPY_TICKS_SPEC.sorted_values
+    """Return all MT5 COPY_TICKS values from pdmt5."""
+    return tuple(pdmt5.list_copy_ticks_values())
 
 
 def get_mt5_copy_ticks_names() -> tuple[str, ...]:
-    """Return all MT5 COPY_TICKS names from the pdmt5 MT5 module copy."""
-    return _COPY_TICKS_SPEC.sorted_names
+    """Return all MT5 COPY_TICKS names from pdmt5."""
+    return tuple(pdmt5.list_copy_ticks_names())
 
 
 def get_mt5_copy_ticks_examples() -> list[int]:
     """Return common MT5 COPY_TICKS integer examples."""
-    return _COPY_TICKS_SPEC.example_values
+    return [pdmt5.COPY_TICKS_MAP[name] for name in _COPY_TICKS_EXAMPLE_NAMES]
 
 
 def get_mt5_copy_ticks_example_names() -> list[str]:
     """Return common MT5 COPY_TICKS example names."""
-    return _COPY_TICKS_SPEC.example_name_list
+    return list(_COPY_TICKS_EXAMPLE_NAMES)
 
 
 def _validate_mt5_timeframe(value: object) -> int:
@@ -255,7 +120,7 @@ def _validate_mt5_timeframe(value: object) -> int:
     Returns:
         The validated integer timeframe value.
     """
-    return _parse_mt5_constant(value, spec=_TIMEFRAME_SPEC)
+    return pdmt5.parse_timeframe(value)
 
 
 def _validate_mt5_copy_ticks(value: object) -> int:
@@ -264,27 +129,27 @@ def _validate_mt5_copy_ticks(value: object) -> int:
     Returns:
         The validated integer COPY_TICKS value.
     """
-    return _parse_mt5_constant(value, spec=_COPY_TICKS_SPEC)
+    return pdmt5.parse_copy_ticks(value)
 
 
 def get_mt5_order_type_values() -> tuple[int, ...]:
-    """Return all available MT5 ORDER_TYPE values from the pdmt5 MT5 module copy."""
-    return _ORDER_TYPE_SPEC.sorted_values
+    """Return all available MT5 ORDER_TYPE values from pdmt5."""
+    return tuple(pdmt5.list_order_type_values())
 
 
 def get_mt5_order_type_names() -> tuple[str, ...]:
-    """Return all available MT5 ORDER_TYPE names from the pdmt5 MT5 module copy."""
-    return _ORDER_TYPE_SPEC.sorted_names
+    """Return all available MT5 ORDER_TYPE names from pdmt5."""
+    return tuple(pdmt5.list_order_type_names())
 
 
 def get_mt5_order_type_examples() -> list[int]:
     """Return common MT5 ORDER_TYPE integer examples."""
-    return _ORDER_TYPE_SPEC.example_values
+    return [pdmt5.ORDER_TYPE_MAP[name] for name in _ORDER_TYPE_EXAMPLE_NAMES]
 
 
 def get_mt5_order_type_example_names() -> list[str]:
     """Return common MT5 ORDER_TYPE example names."""
-    return _ORDER_TYPE_SPEC.example_name_list
+    return list(_ORDER_TYPE_EXAMPLE_NAMES)
 
 
 def _validate_mt5_order_type(value: object) -> int:
@@ -293,7 +158,7 @@ def _validate_mt5_order_type(value: object) -> int:
     Returns:
         The validated integer ORDER_TYPE value.
     """
-    return _parse_mt5_constant(value, spec=_ORDER_TYPE_SPEC)
+    return pdmt5.parse_order_type(value)
 
 
 Mt5Timeframe: TypeAlias = Annotated[
@@ -301,7 +166,7 @@ Mt5Timeframe: TypeAlias = Annotated[
     BeforeValidator(_validate_mt5_timeframe),
     WithJsonSchema(
         _build_mt5_constant_json_schema(
-            description=_TIMEFRAME_SPEC.schema_description,
+            description=_TIMEFRAME_DESCRIPTION,
             names=get_mt5_timeframe_names(),
             values=get_mt5_timeframe_values(),
             examples=get_mt5_timeframe_example_names(),
@@ -316,7 +181,7 @@ Mt5CopyTicks: TypeAlias = Annotated[
     BeforeValidator(_validate_mt5_copy_ticks),
     WithJsonSchema(
         _build_mt5_constant_json_schema(
-            description=_COPY_TICKS_SPEC.schema_description,
+            description=_COPY_TICKS_DESCRIPTION,
             names=get_mt5_copy_ticks_names(),
             values=get_mt5_copy_ticks_values(),
             examples=get_mt5_copy_ticks_example_names(),
@@ -331,7 +196,7 @@ Mt5OrderType: TypeAlias = Annotated[
     BeforeValidator(_validate_mt5_order_type),
     WithJsonSchema(
         _build_mt5_constant_json_schema(
-            description=_ORDER_TYPE_SPEC.schema_description,
+            description=_ORDER_TYPE_DESCRIPTION,
             names=get_mt5_order_type_names(),
             values=get_mt5_order_type_values(),
             examples=get_mt5_order_type_example_names(),
@@ -339,6 +204,13 @@ Mt5OrderType: TypeAlias = Annotated[
         mode="validation",
     ),
 ]
+
+
+class ResponseFormat(StrEnum):
+    """Response format enumeration."""
+
+    JSON = "json"
+    PARQUET = "parquet"
 
 
 class ErrorResponse(BaseModel):
@@ -532,7 +404,7 @@ class TicksFromRequest(BaseModel):
         le=100000,
     )
     flags: Mt5CopyTicks = Field(
-        default=_COPY_TICKS_SPEC.members["COPY_TICKS_ALL"],
+        default=pdmt5.COPY_TICKS_MAP["COPY_TICKS_ALL"],
         description=_COPY_TICKS_DESCRIPTION,
     )
     format: ResponseFormat | None = Field(default=None)
@@ -545,7 +417,7 @@ class TicksRangeRequest(BaseModel):
     date_from: datetime = Field(..., description="Start date (ISO 8601)")
     date_to: datetime = Field(..., description="End date (ISO 8601)")
     flags: Mt5CopyTicks = Field(
-        default=_COPY_TICKS_SPEC.members["COPY_TICKS_ALL"],
+        default=pdmt5.COPY_TICKS_MAP["COPY_TICKS_ALL"],
         description=_COPY_TICKS_DESCRIPTION,
     )
     format: ResponseFormat | None = Field(default=None)

--- a/mt5api/models.py
+++ b/mt5api/models.py
@@ -19,7 +19,7 @@ from pydantic import (
 
 _TIMEFRAME_DESCRIPTION = (
     "MetaTrader5 TIMEFRAME constant. Accepts a constant name such as "
-    "TIMEFRAME_M1 or the short alias M1, or the corresponding integer value."
+    "TIMEFRAME_M1, short aliases such as M1, or the corresponding integer value."
 )
 _TIMEFRAME_EXAMPLE_NAMES = (
     "TIMEFRAME_M1",
@@ -44,7 +44,7 @@ _COPY_TICKS_EXAMPLE_NAMES = (
 )
 _ORDER_TYPE_DESCRIPTION = (
     "MetaTrader5 ORDER_TYPE constant. Accepts a constant name such as "
-    "ORDER_TYPE_BUY or the short alias BUY, or the corresponding integer value."
+    "ORDER_TYPE_BUY, short aliases such as BUY, or the corresponding integer value."
 )
 _ORDER_TYPE_EXAMPLE_NAMES = (
     "ORDER_TYPE_BUY",
@@ -55,8 +55,8 @@ _ORDER_TYPE_EXAMPLE_NAMES = (
 def _build_mt5_constant_json_schema(
     *,
     description: str,
-    names: tuple[str, ...] | list[str],
-    values: tuple[int, ...] | list[int],
+    names: tuple[str, ...],
+    values: tuple[int, ...],
     examples: list[str],
 ) -> dict[str, Any]:
     """Build a JSON schema for a name-or-integer MT5 constant parameter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mt5api"
-version = "0.2.0"
+version = "0.3.0"
 description = "MetaTrader 5 REST API"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
@@ -32,9 +32,6 @@ Repository = "https://github.com/dceoy/mt5api.git"
 
 [tool.uv]
 required-environments = ["platform_system == 'Windows'"]
-constraint-dependencies = [
-  "pygments >= 2.20.0",
-]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
   "uvicorn[standard] >= 0.32.0",
   "pyarrow >= 18.0.0",
   "python-multipart >= 0.0.9",
-  "python-jose[cryptography] >= 3.3.0",
   "passlib[bcrypt] >= 1.7.4",
   "httpx >= 0.27.0",
 ]
@@ -34,6 +33,9 @@ Repository = "https://github.com/dceoy/mt5api.git"
 
 [tool.uv]
 required-environments = ["platform_system == 'Windows'"]
+constraint-dependencies = [
+  "pygments >= 2.20.0",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
   "uvicorn[standard] >= 0.32.0",
   "pyarrow >= 18.0.0",
   "python-multipart >= 0.0.9",
-  "passlib[bcrypt] >= 1.7.4",
   "httpx >= 0.27.0",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">= 3.11, < 3.14"
 dependencies = [
-  "MetaTrader5 >= 5.0.4424; sys_platform == 'win32'",
-  "pdmt5 >= 0.2.1",
+  "pdmt5 >= 0.3.0",
   "fastapi >= 0.115.0",
   "uvicorn[standard] >= 0.32.0",
   "pyarrow >= 18.0.0",

--- a/tests/mt5_constants.py
+++ b/tests/mt5_constants.py
@@ -36,7 +36,7 @@ class Mt5CopyTicks(IntEnum):
 
     COPY_TICKS_INFO = 1
     COPY_TICKS_TRADE = 2
-    COPY_TICKS_ALL = 3
+    COPY_TICKS_ALL = -1
 
 
 class Mt5BookType(IntEnum):

--- a/tests/openapi_mt5_constants.py
+++ b/tests/openapi_mt5_constants.py
@@ -1,0 +1,34 @@
+"""Shared OpenAPI schema assertions for MT5 constant metadata."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mt5api.models import (
+    get_mt5_order_type_example_names,
+    get_mt5_order_type_names,
+    get_mt5_order_type_values,
+)
+
+ORDER_TYPE_DESCRIPTION = (
+    "MetaTrader5 ORDER_TYPE constant. Accepts a constant name such as "
+    "ORDER_TYPE_BUY, short aliases such as BUY, or the corresponding integer value."
+)
+VALID_ORDER_TYPE_NAMES = list(get_mt5_order_type_names())
+VALID_ORDER_TYPE_VALUES = list(get_mt5_order_type_values())
+ORDER_TYPE_EXAMPLES = get_mt5_order_type_example_names()
+
+
+def assert_openapi_mt5_order_type_schema(schema: dict[str, Any]) -> None:
+    """Assert an OpenAPI schema documents ORDER_TYPE names, values, and examples."""
+    string_schema = next(
+        member for member in schema["anyOf"] if member["type"] == "string"
+    )
+    integer_schema = next(
+        member for member in schema["anyOf"] if member["type"] == "integer"
+    )
+
+    assert sorted(string_schema["enum"]) == sorted(VALID_ORDER_TYPE_NAMES)
+    assert sorted(integer_schema["enum"]) == sorted(VALID_ORDER_TYPE_VALUES)
+    assert schema["examples"] == ORDER_TYPE_EXAMPLES
+    assert schema["description"] == ORDER_TYPE_DESCRIPTION

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -8,6 +8,7 @@ import pytest
 from pdmt5.mt5 import Mt5RuntimeError
 
 from tests.mt5_constants import Mt5OrderType
+from tests.openapi_mt5_constants import assert_openapi_mt5_order_type_schema
 
 if TYPE_CHECKING:
     from unittest.mock import Mock
@@ -294,3 +295,18 @@ def test_get_calc_profit_returns_service_unavailable_on_mt5_error(
     payload = response.json()
     assert payload["title"] == "MT5 Terminal Error"
     assert "order_calc_profit returned None" in payload["detail"]
+
+
+def test_openapi_documents_mt5_order_type_consistently(
+    client: TestClient,
+) -> None:
+    """Calc endpoints should expose MT5 ORDER_TYPE names and integer values."""
+    openapi = client.get("/openapi.json").json()
+    paths = ("/calc/margin", "/calc/profit")
+
+    for path in paths:
+        parameters = openapi["paths"][path]["get"]["parameters"]
+        action_parameter = next(
+            parameter for parameter in parameters if parameter["name"] == "action"
+        )
+        assert_openapi_mt5_order_type_schema(action_parameter["schema"])

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -277,13 +277,13 @@ def test_openapi_documents_mt5_timeframes_consistently(
             if schema["type"] == "integer"
         )
 
-        assert sorted(string_schema["enum"]) == VALID_TIMEFRAME_NAMES
-        assert sorted(integer_schema["enum"]) == VALID_TIMEFRAME_VALUES
+        assert sorted(string_schema["enum"]) == sorted(VALID_TIMEFRAME_NAMES)
+        assert sorted(integer_schema["enum"]) == sorted(VALID_TIMEFRAME_VALUES)
         assert timeframe_schema["examples"] == TIMEFRAME_EXAMPLES
         assert (
             timeframe_schema["description"]
             == "MetaTrader5 TIMEFRAME constant. Accepts a constant name such as "
-            "TIMEFRAME_M1 or the corresponding integer value."
+            "TIMEFRAME_M1 or the short alias M1, or the corresponding integer value."
         )
 
 
@@ -442,13 +442,14 @@ def test_openapi_documents_mt5_copy_ticks_consistently(
             schema for schema in flag_schema["anyOf"] if schema["type"] == "integer"
         )
 
-        assert sorted(string_schema["enum"]) == VALID_TICK_FLAG_NAMES
-        assert sorted(integer_schema["enum"]) == VALID_TICK_FLAG_VALUES
+        assert sorted(string_schema["enum"]) == sorted(VALID_TICK_FLAG_NAMES)
+        assert sorted(integer_schema["enum"]) == sorted(VALID_TICK_FLAG_VALUES)
         assert flag_schema["examples"] == TICK_FLAG_EXAMPLES
         assert (
             flag_schema["description"]
             == "MetaTrader5 COPY_TICKS constant. Accepts COPY_TICKS_INFO, "
-            "COPY_TICKS_TRADE, COPY_TICKS_ALL, or the corresponding integer value."
+            "COPY_TICKS_TRADE, COPY_TICKS_ALL, short aliases such as ALL, "
+            "or the corresponding integer value."
         )
 
 

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -283,7 +283,8 @@ def test_openapi_documents_mt5_timeframes_consistently(
         assert (
             timeframe_schema["description"]
             == "MetaTrader5 TIMEFRAME constant. Accepts a constant name such as "
-            "TIMEFRAME_M1 or the short alias M1, or the corresponding integer value."
+            "TIMEFRAME_M1, short aliases such as M1, "
+            "or the corresponding integer value."
         )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -80,30 +80,6 @@ def test_rates_from_request_accepts_mt5_timeframe_inputs(
     assert request.timeframe == expected
 
 
-def test_rates_from_request_accepts_mt5_timeframe_name() -> None:
-    """Rates requests accept MT5 timeframe constant names."""
-    request = RatesFromRequest.model_validate({
-        "symbol": "EURUSD",
-        "timeframe": "TIMEFRAME_M1",
-        "date_from": datetime(2024, 1, 1, tzinfo=UTC),
-        "count": 10,
-    })
-
-    assert request.timeframe == int(Mt5Timeframe.TIMEFRAME_M1)
-
-
-def test_rates_from_request_accepts_mt5_timeframe_integer_string() -> None:
-    """Rates requests accept stringified MT5 timeframe integer values."""
-    request = RatesFromRequest.model_validate({
-        "symbol": "EURUSD",
-        "timeframe": str(int(Mt5Timeframe.TIMEFRAME_M1)),
-        "date_from": datetime(2024, 1, 1, tzinfo=UTC),
-        "count": 10,
-    })
-
-    assert request.timeframe == int(Mt5Timeframe.TIMEFRAME_M1)
-
-
 @pytest.mark.parametrize(
     ("flags", "expected"),
     [
@@ -128,21 +104,9 @@ def test_ticks_from_request_accepts_mt5_copy_ticks_inputs(
     assert request.flags == expected
 
 
-def test_ticks_from_request_accepts_mt5_copy_ticks_name() -> None:
-    """Tick requests accept MT5 COPY_TICKS constant names."""
-    request = TicksFromRequest.model_validate({
-        "symbol": "EURUSD",
-        "date_from": datetime(2024, 1, 1, tzinfo=UTC),
-        "count": 10,
-        "flags": "COPY_TICKS_ALL",
-    })
-
-    assert request.flags == int(Mt5CopyTicks.COPY_TICKS_ALL)
-
-
 @pytest.mark.parametrize(
     "timeframe",
-    [True, 1.0, None, [], 99],
+    [True, 1.0, None, [], 99, "BOGUS"],
 )
 def test_rates_from_request_rejects_invalid_mt5_timeframe_values(
     timeframe: object,
@@ -157,28 +121,20 @@ def test_rates_from_request_rejects_invalid_mt5_timeframe_values(
         })
 
 
-def test_rates_from_request_rejects_invalid_mt5_timeframe_type() -> None:
-    """Rates requests reject non-string, non-integer timeframe values."""
-    with pytest.raises(ValidationError, match="Invalid MT5 timeframe"):
-        RatesFromRequest.model_validate({
-            "symbol": "EURUSD",
-            "timeframe": [],
-            "date_from": datetime(2024, 1, 1, tzinfo=UTC),
-            "count": 10,
-        })
-
-
-def test_ticks_from_request_rejects_invalid_mt5_copy_ticks_value() -> None:
-    """Tick requests reject unsupported MT5 COPY_TICKS integer values."""
-    with pytest.raises(
-        ValidationError,
-        match="Unsupported MT5 COPY_TICKS flag value: 99",
-    ):
+@pytest.mark.parametrize(
+    "flags",
+    [True, 1.0, None, [], 99, "BOGUS"],
+)
+def test_ticks_from_request_rejects_invalid_mt5_copy_ticks_values(
+    flags: object,
+) -> None:
+    """Tick requests reject bool, float, None, objects, and unsupported values."""
+    with pytest.raises(ValidationError):
         TicksFromRequest.model_validate({
             "symbol": "EURUSD",
             "date_from": datetime(2024, 1, 1, tzinfo=UTC),
             "count": 10,
-            "flags": 99,
+            "flags": flags,
         })
 
 
@@ -214,16 +170,21 @@ def test_calc_margin_request_accepts_order_type_inputs(
     assert request.action == expected
 
 
-def test_calc_margin_request_accepts_order_type_name() -> None:
-    """Calc margin request accepts ORDER_TYPE constant names."""
-    request = CalcMarginRequest.model_validate({
-        "action": "ORDER_TYPE_BUY",
-        "symbol": "EURUSD",
-        "volume": 0.1,
-        "price": 1.085,
-    })
-
-    assert request.action == int(Mt5OrderType.ORDER_TYPE_BUY)
+@pytest.mark.parametrize(
+    "action",
+    [True, 1.0, None, [], 99, "BOGUS"],
+)
+def test_calc_margin_request_rejects_invalid_order_type_values(
+    action: object,
+) -> None:
+    """Calc margin requests reject invalid ORDER_TYPE inputs."""
+    with pytest.raises(ValidationError):
+        CalcMarginRequest.model_validate({
+            "action": action,
+            "symbol": "EURUSD",
+            "volume": 0.1,
+            "price": 1.085,
+        })
 
 
 def test_history_total_request_rejects_invalid_date_range() -> None:
@@ -311,16 +272,6 @@ def test_trade_request_rejects_unknown_field() -> None:
             },
             "greater than 0",
         ),
-        (
-            {
-                "action": 1,
-                "symbol": "EURUSD",
-                "volume": 0.1,
-                "type": 99,
-                "price": 1.085,
-            },
-            "Unsupported MT5 ORDER_TYPE value: 99",
-        ),
     ],
 )
 def test_trade_request_rejects_invalid_core_fields(
@@ -330,3 +281,15 @@ def test_trade_request_rejects_invalid_core_fields(
     """Trade requests should validate core field constraints."""
     with pytest.raises(ValidationError, match=match):
         TradeRequest.model_validate(payload)
+
+
+def test_trade_request_rejects_unsupported_order_type() -> None:
+    """Trade requests reject unsupported ORDER_TYPE values from pdmt5."""
+    with pytest.raises(ValidationError):
+        TradeRequest.model_validate({
+            "action": 1,
+            "symbol": "EURUSD",
+            "volume": 0.1,
+            "type": 99,
+            "price": 1.085,
+        })

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,6 +56,30 @@ def test_mt5_constant_example_helpers_return_integer_examples() -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    ("timeframe", "expected"),
+    [
+        ("TIMEFRAME_M1", int(Mt5Timeframe.TIMEFRAME_M1)),
+        ("M1", int(Mt5Timeframe.TIMEFRAME_M1)),
+        (int(Mt5Timeframe.TIMEFRAME_M1), int(Mt5Timeframe.TIMEFRAME_M1)),
+        (str(int(Mt5Timeframe.TIMEFRAME_M1)), int(Mt5Timeframe.TIMEFRAME_M1)),
+    ],
+)
+def test_rates_from_request_accepts_mt5_timeframe_inputs(
+    timeframe: object,
+    expected: int,
+) -> None:
+    """Rates requests accept official names, aliases, integers, and numeric strings."""
+    request = RatesFromRequest.model_validate({
+        "symbol": "EURUSD",
+        "timeframe": timeframe,
+        "date_from": datetime(2024, 1, 1, tzinfo=UTC),
+        "count": 10,
+    })
+
+    assert request.timeframe == expected
+
+
 def test_rates_from_request_accepts_mt5_timeframe_name() -> None:
     """Rates requests accept MT5 timeframe constant names."""
     request = RatesFromRequest.model_validate({
@@ -80,6 +104,30 @@ def test_rates_from_request_accepts_mt5_timeframe_integer_string() -> None:
     assert request.timeframe == int(Mt5Timeframe.TIMEFRAME_M1)
 
 
+@pytest.mark.parametrize(
+    ("flags", "expected"),
+    [
+        ("COPY_TICKS_ALL", int(Mt5CopyTicks.COPY_TICKS_ALL)),
+        ("ALL", int(Mt5CopyTicks.COPY_TICKS_ALL)),
+        (int(Mt5CopyTicks.COPY_TICKS_INFO), int(Mt5CopyTicks.COPY_TICKS_INFO)),
+        (str(int(Mt5CopyTicks.COPY_TICKS_TRADE)), int(Mt5CopyTicks.COPY_TICKS_TRADE)),
+    ],
+)
+def test_ticks_from_request_accepts_mt5_copy_ticks_inputs(
+    flags: object,
+    expected: int,
+) -> None:
+    """Tick requests accept official names, aliases, integers, and numeric strings."""
+    request = TicksFromRequest.model_validate({
+        "symbol": "EURUSD",
+        "date_from": datetime(2024, 1, 1, tzinfo=UTC),
+        "count": 10,
+        "flags": flags,
+    })
+
+    assert request.flags == expected
+
+
 def test_ticks_from_request_accepts_mt5_copy_ticks_name() -> None:
     """Tick requests accept MT5 COPY_TICKS constant names."""
     request = TicksFromRequest.model_validate({
@@ -92,9 +140,26 @@ def test_ticks_from_request_accepts_mt5_copy_ticks_name() -> None:
     assert request.flags == int(Mt5CopyTicks.COPY_TICKS_ALL)
 
 
+@pytest.mark.parametrize(
+    "timeframe",
+    [True, 1.0, None, [], 99],
+)
+def test_rates_from_request_rejects_invalid_mt5_timeframe_values(
+    timeframe: object,
+) -> None:
+    """Rates requests reject bool, float, None, objects, and unsupported integers."""
+    with pytest.raises(ValidationError):
+        RatesFromRequest.model_validate({
+            "symbol": "EURUSD",
+            "timeframe": timeframe,
+            "date_from": datetime(2024, 1, 1, tzinfo=UTC),
+            "count": 10,
+        })
+
+
 def test_rates_from_request_rejects_invalid_mt5_timeframe_type() -> None:
     """Rates requests reject non-string, non-integer timeframe values."""
-    with pytest.raises(ValidationError, match="constant name or integer value"):
+    with pytest.raises(ValidationError, match="Invalid MT5 timeframe"):
         RatesFromRequest.model_validate({
             "symbol": "EURUSD",
             "timeframe": [],
@@ -107,7 +172,7 @@ def test_ticks_from_request_rejects_invalid_mt5_copy_ticks_value() -> None:
     """Tick requests reject unsupported MT5 COPY_TICKS integer values."""
     with pytest.raises(
         ValidationError,
-        match="Unsupported metatrader5 copy_ticks constant value: 99",
+        match="Unsupported MT5 COPY_TICKS flag value: 99",
     ):
         TicksFromRequest.model_validate({
             "symbol": "EURUSD",
@@ -123,6 +188,30 @@ def test_mt5_order_type_example_helpers_return_integer_examples() -> None:
         int(Mt5OrderType.ORDER_TYPE_BUY),
         int(Mt5OrderType.ORDER_TYPE_SELL),
     ]
+
+
+@pytest.mark.parametrize(
+    ("action", "expected"),
+    [
+        ("ORDER_TYPE_BUY", int(Mt5OrderType.ORDER_TYPE_BUY)),
+        ("BUY", int(Mt5OrderType.ORDER_TYPE_BUY)),
+        (int(Mt5OrderType.ORDER_TYPE_SELL), int(Mt5OrderType.ORDER_TYPE_SELL)),
+        (str(int(Mt5OrderType.ORDER_TYPE_SELL)), int(Mt5OrderType.ORDER_TYPE_SELL)),
+    ],
+)
+def test_calc_margin_request_accepts_order_type_inputs(
+    action: object,
+    expected: int,
+) -> None:
+    """Calc margin requests accept official names, aliases, integers, and strings."""
+    request = CalcMarginRequest.model_validate({
+        "action": action,
+        "symbol": "EURUSD",
+        "volume": 0.1,
+        "price": 1.085,
+    })
+
+    assert request.action == expected
 
 
 def test_calc_margin_request_accepts_order_type_name() -> None:
@@ -230,7 +319,7 @@ def test_trade_request_rejects_unknown_field() -> None:
                 "type": 99,
                 "price": 1.085,
             },
-            "Unsupported metatrader5 order_type constant value: 99",
+            "Unsupported MT5 ORDER_TYPE value: 99",
         ),
     ],
 )

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from mt5api import dependencies
 from mt5api.main import app
 from mt5api.routers import health
+from tests.openapi_mt5_constants import assert_openapi_mt5_order_type_schema
 
 if TYPE_CHECKING:
     from unittest.mock import Mock
@@ -521,3 +522,14 @@ def test_openapi_excludes_order_send_endpoint(
     openapi = client.get("/openapi.json").json()
 
     assert "/order/send" not in openapi["paths"]
+
+
+def test_openapi_documents_mt5_order_type_on_order_check(
+    client: TestClient,
+) -> None:
+    """Order check should expose ORDER_TYPE metadata on TradeRequest.type."""
+    openapi = client.get("/openapi.json").json()
+    trade_request_schema = openapi["components"]["schemas"]["TradeRequest"]
+    order_type_schema = trade_request_schema["properties"]["type"]
+
+    assert_openapi_mt5_order_type_schema(order_type_schema)

--- a/uv.lock
+++ b/uv.lock
@@ -10,9 +10,6 @@ required-markers = [
     "sys_platform == 'win32'",
 ]
 
-[manifest]
-constraints = [{ name = "pygments", specifier = ">=2.20.0" }]
-
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -559,7 +556,7 @@ wheels = [
 
 [[package]]
 name = "mt5api"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -723,7 +723,6 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
-    { name = "metatrader5", marker = "sys_platform == 'win32'" },
     { name = "passlib", extra = ["bcrypt"] },
     { name = "pdmt5" },
     { name = "pyarrow" },
@@ -753,9 +752,8 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "metatrader5", marker = "sys_platform == 'win32'", specifier = ">=5.0.4424" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
-    { name = "pdmt5", specifier = ">=0.2.1" },
+    { name = "pdmt5", specifier = ">=0.3.0" },
     { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
@@ -946,16 +944,16 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "0.2.1"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },
     { name = "pandas" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/06/056028b6e5ec3072508e2d785d85d4d1be13cc2623f4b8f84f5033d7d03b/pdmt5-0.2.1.tar.gz", hash = "sha256:1b7886f7f20c8783c984c441474faac4a497a61fb9370baa6619db31daea874c", size = 118936, upload-time = "2025-11-12T15:37:09.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/cc/c8fa3a01e0e34178fec8527992f7bb8eda5881477ce23aaacaa9b2ef7bec/pdmt5-0.3.0.tar.gz", hash = "sha256:bb612d5c2695eafac9b2a7b74756e13bd383d7e5517bd90c9a2efa92492c484c", size = 215100, upload-time = "2026-06-11T13:26:46.976Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/d1/3c5b5969aac36149f13c5f2b05f58e110b6a5a8901b1aad821f02c9e8a74/pdmt5-0.2.1-py3-none-any.whl", hash = "sha256:d91f92ee4c378b0d2695a6d40531476b66e92a5e8801877c1aff1893278d038b", size = 22690, upload-time = "2025-11-12T15:37:07.988Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/03/b12cc4c9db983d971c9172b3765161b6d91136d0624e6718a04dd815e7a1/pdmt5-0.3.0-py3-none-any.whl", hash = "sha256:5388b406cc583202600cfe22c9d781679b1d931b1ed5a2b5dcf37c566149b49f", size = 26250, upload-time = "2026-06-11T13:26:45.689Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -67,63 +67,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bcrypt"
-version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
-    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
-    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
-    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
-    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
-    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
-    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
-    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
-    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
-    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
-    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
-    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
-    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
-    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
-    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
-    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
-    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
-    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
-    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/75/4aa9f5a4d40d762892066ba1046000b329c7cd58e888a6db878019b282dc/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7edda91d5ab52b15636d9c30da87d2cc84f426c72b9dba7a9b4fe142ba11f534", size = 271180, upload-time = "2025-09-25T19:50:38.575Z" },
-    { url = "https://files.pythonhosted.org/packages/54/79/875f9558179573d40a9cc743038ac2bf67dfb79cecb1e8b5d70e88c94c3d/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4", size = 273791, upload-time = "2025-09-25T19:50:39.913Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/fe/975adb8c216174bf70fc17535f75e85ac06ed5252ea077be10d9cff5ce24/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911", size = 270746, upload-time = "2025-09-25T19:50:43.306Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/f8/972c96f5a2b6c4b3deca57009d93e946bbdbe2241dca9806d502f29dd3ee/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4", size = 273375, upload-time = "2025-09-25T19:50:45.43Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -621,7 +564,6 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
-    { name = "passlib", extra = ["bcrypt"] },
     { name = "pdmt5" },
     { name = "pyarrow" },
     { name = "python-multipart" },
@@ -649,7 +591,6 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pdmt5", specifier = ">=0.3.0" },
     { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
@@ -813,20 +754,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/c6/df1fe324248424f77b89371116dab5243db7f052c32cc9fe7442ad9c5f75/pandas_stubs-2.3.3.260113-py3-none-any.whl", hash = "sha256:ec070b5c576e1badf12544ae50385872f0631fc35d99d00dc598c2954ec564d3", size = 168246, upload-time = "2026-01-13T22:30:15.244Z" },
-]
-
-[[package]]
-name = "passlib"
-version = "1.7.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
-]
-
-[package.optional-dependencies]
-bcrypt = [
-    { name = "bcrypt" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,9 @@ required-markers = [
     "sys_platform == 'win32'",
 ]
 
+[manifest]
+constraints = [{ name = "pygments", specifier = ">=2.20.0" }]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -127,54 +130,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
-]
-
-[[package]]
-name = "cffi"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
-    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
-    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
-    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
-    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
-    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
-    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
-    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
 ]
 
 [[package]]
@@ -319,63 +274,6 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
-]
-
-[[package]]
-name = "cryptography"
-version = "46.0.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
-    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
-    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879, upload-time = "2026-04-08T01:57:38.664Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700, upload-time = "2026-04-08T01:57:40.625Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982, upload-time = "2026-04-08T01:57:42.725Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.19.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793, upload-time = "2025-03-13T11:52:43.25Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607, upload-time = "2025-03-13T11:52:41.757Z" },
 ]
 
 [[package]]
@@ -726,7 +624,6 @@ dependencies = [
     { name = "passlib", extra = ["bcrypt"] },
     { name = "pdmt5" },
     { name = "pyarrow" },
-    { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -755,7 +652,6 @@ requires-dist = [
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pdmt5", specifier = ">=0.3.0" },
     { name = "pyarrow", specifier = ">=18.0.0" },
-    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
@@ -1011,24 +907,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
-name = "pycparser"
-version = "3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
-]
-
-[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1114,11 +992,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -1224,25 +1102,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
@@ -1313,18 +1172,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors `mt5api` to use **pdmt5 >= 0.3.0** as the canonical MT5 constant parsing and OpenAPI schema metadata layer, keeping `mt5api` as a FastAPI/HTTP adapter rather than duplicating MT5 domain constants.

## Changes

- **Dependency bump**: `pdmt5 >= 0.3.0`; removed direct `MetaTrader5` dependency (pdmt5 owns the Windows MT5 API dependency)
- **`mt5api/models.py`**:
  - Removed `_get_mt5_module()`, `Mt5ConstantSpec`, and custom `_parse_mt5_constant`
  - Validators now call `pdmt5.parse_timeframe`, `parse_copy_ticks`, and `parse_order_type`
  - JSON schema enums built from `pdmt5.list_*_names()` / `list_*_values()`
  - Defaults for tick flags use `pdmt5.COPY_TICKS_MAP`
- **CI fix**: Removed unused `python-jose` dependency (auth uses API keys via `hmac`, not JWT); constrained `pygments >= 2.20.0` to clear `uv audit` advisories
- **Tests**: Expanded validation coverage for official names, short aliases, numeric strings, and rejection cases; aligned `COPY_TICKS_ALL` with pdmt5 canonical value (`-1`); OpenAPI schema tests compare sorted enum sets
- **Docs**: README and `docs/index.md` clarify architecture — pdmt5 = core client/constants layer, mt5api = HTTP adapter, mt5cli = sibling (not a dependency)

## Validation

- `uv sync`
- `uv audit --locked`
- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest` (231 passed, 100% coverage)
- `uv run mkdocs build`
- CI: lint-and-scan and test passing

## Notes

- OpenAPI schemas now include pdmt5 short aliases (e.g. `M1`, `ALL`, `BUY`) alongside official constant names
- Validation error messages follow pdmt5's canonical wording
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dddbf823-0ffc-4803-854b-fe8389b67e7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dddbf823-0ffc-4803-854b-fe8389b67e7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

