### PR TITLE
docs: clarify mt5api operational scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ constant parsing. mt5api adds optional API-key auth and JSON/Parquet response
 formatting.
 
 The exposed operational surface is deliberately narrow: mt5api validates trade
-requests and manages terminal-side subscriptions or MarketWatch visibility, but
-it does not expose live order-send endpoints or implement strategy orchestration.
+requests, manages terminal-side subscriptions and MarketWatch visibility, and
+supports reconnecting the terminal to a different MT5 account via
+`POST /connection/login`, but it does not expose live order-send endpoints or
+implement strategy orchestration.
 
 The API server must run on Windows. pdmt5 connects through the MetaTrader 5
 Python API, which is supported only on Windows, so you must host `mt5api` on a

--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@ MetaTrader 5 REST API
 
 [![CI/CD](https://github.com/dceoy/mt5api/actions/workflows/ci.yml/badge.svg)](https://github.com/dceoy/mt5api/actions/workflows/ci.yml)
 
-mt5api exposes MT5 market data, account info, trading history, and trading
-operations over HTTP. It is a FastAPI/HTTP adapter over
-[`pdmt5`](https://github.com/dceoy/pdmt5), which provides the core MT5 client,
-dataframe/trading primitives, and canonical MT5 constant parsing. mt5api adds
-optional API-key auth and JSON/Parquet response formatting.
+mt5api exposes MT5 market data, account info, trading history, trading state,
+order validation, and operational terminal endpoints over HTTP. It is a
+FastAPI/HTTP adapter over [`pdmt5`](https://github.com/dceoy/pdmt5), which
+provides the core MT5 client, dataframe/order primitives, and canonical MT5
+constant parsing. mt5api adds optional API-key auth and JSON/Parquet response
+formatting.
+
+The exposed operational surface is deliberately narrow: mt5api validates trade
+requests and manages terminal-side subscriptions or MarketWatch visibility, but
+it does not expose live order-send endpoints or implement strategy orchestration.
 
 The API server must run on Windows. pdmt5 connects through the MetaTrader 5
 Python API, which is supported only on Windows, so you must host `mt5api` on a
@@ -43,8 +48,8 @@ graph TB
 
 ## Features
 
-- REST endpoints for symbols, market data, account info, orders, history,
-  calculations, and trading operations
+- REST endpoints for symbols, market data, account info, orders, positions,
+  history, margin/profit calculations, order validation, and terminal operations
 - JSON and Apache Parquet responses (content negotiation)
 - Optional API key authentication
 - Structured JSON logging


### PR DESCRIPTION
## Summary
- Clarify that mt5api exposes market data, account state, history, order validation, and narrow operational terminal endpoints over HTTP.
- Avoid implying that mt5api exposes live order-send endpoints or strategy orchestration.
- Align the feature list with the documented endpoint surface.

## Testing
- Not run; documentation-only change.