### PR TITLE
Update pdmt5 dependency to 1.2.0

### DIFF
--- a/mt5api/constants.py
+++ b/mt5api/constants.py
@@ -6,7 +6,7 @@ API_DESCRIPTION = (
     "Provides market data, account information, trading history, calculations, "
     "and safe operational endpoints via HTTP."
 )
-API_VERSION = "1.0.1"
+API_VERSION = "1.0.2"
 API_DOCS_URL = "/docs"
 API_REDOC_URL = "/redoc"
 API_OPENAPI_URL = "/openapi.json"

--- a/mt5api/models.py
+++ b/mt5api/models.py
@@ -6,7 +6,22 @@ from datetime import datetime  # noqa: TC003
 from enum import StrEnum
 from typing import Annotated, Any, Self, TypeAlias
 
-import pdmt5
+from pdmt5 import (
+    COPY_TICKS_MAP,
+    ORDER_TYPE_MAP,
+    TIMEFRAME_MAP,
+    parse_copy_ticks,
+    parse_order_type,
+    parse_timeframe,
+)
+from pdmt5.constants import (
+    list_copy_ticks_names,
+    list_copy_ticks_values,
+    list_order_type_names,
+    list_order_type_values,
+    list_timeframe_names,
+    list_timeframe_values,
+)
 from pydantic import (
     BaseModel,
     BeforeValidator,
@@ -76,17 +91,17 @@ def _build_mt5_constant_json_schema(
 
 def get_mt5_timeframe_values() -> tuple[int, ...]:
     """Return all available MT5 timeframe values from pdmt5."""
-    return tuple(pdmt5.list_timeframe_values())
+    return tuple(list_timeframe_values())
 
 
 def get_mt5_timeframe_names() -> tuple[str, ...]:
     """Return all available MT5 timeframe names from pdmt5."""
-    return tuple(pdmt5.list_timeframe_names())
+    return tuple(list_timeframe_names())
 
 
 def get_mt5_timeframe_examples() -> list[int]:
     """Return common MT5 timeframe examples from pdmt5."""
-    return [pdmt5.TIMEFRAME_MAP[name] for name in _TIMEFRAME_EXAMPLE_NAMES]
+    return [TIMEFRAME_MAP[name] for name in _TIMEFRAME_EXAMPLE_NAMES]
 
 
 def get_mt5_timeframe_example_names() -> list[str]:
@@ -96,17 +111,17 @@ def get_mt5_timeframe_example_names() -> list[str]:
 
 def get_mt5_copy_ticks_values() -> tuple[int, ...]:
     """Return all MT5 COPY_TICKS values from pdmt5."""
-    return tuple(pdmt5.list_copy_ticks_values())
+    return tuple(list_copy_ticks_values())
 
 
 def get_mt5_copy_ticks_names() -> tuple[str, ...]:
     """Return all MT5 COPY_TICKS names from pdmt5."""
-    return tuple(pdmt5.list_copy_ticks_names())
+    return tuple(list_copy_ticks_names())
 
 
 def get_mt5_copy_ticks_examples() -> list[int]:
     """Return common MT5 COPY_TICKS integer examples."""
-    return [pdmt5.COPY_TICKS_MAP[name] for name in _COPY_TICKS_EXAMPLE_NAMES]
+    return [COPY_TICKS_MAP[name] for name in _COPY_TICKS_EXAMPLE_NAMES]
 
 
 def get_mt5_copy_ticks_example_names() -> list[str]:
@@ -120,7 +135,7 @@ def _validate_mt5_timeframe(value: object) -> int:
     Returns:
         The validated integer timeframe value.
     """
-    return pdmt5.parse_timeframe(value)
+    return parse_timeframe(value)
 
 
 def _validate_mt5_copy_ticks(value: object) -> int:
@@ -129,22 +144,22 @@ def _validate_mt5_copy_ticks(value: object) -> int:
     Returns:
         The validated integer COPY_TICKS value.
     """
-    return pdmt5.parse_copy_ticks(value)
+    return parse_copy_ticks(value)
 
 
 def get_mt5_order_type_values() -> tuple[int, ...]:
     """Return all available MT5 ORDER_TYPE values from pdmt5."""
-    return tuple(pdmt5.list_order_type_values())
+    return tuple(list_order_type_values())
 
 
 def get_mt5_order_type_names() -> tuple[str, ...]:
     """Return all available MT5 ORDER_TYPE names from pdmt5."""
-    return tuple(pdmt5.list_order_type_names())
+    return tuple(list_order_type_names())
 
 
 def get_mt5_order_type_examples() -> list[int]:
     """Return common MT5 ORDER_TYPE integer examples."""
-    return [pdmt5.ORDER_TYPE_MAP[name] for name in _ORDER_TYPE_EXAMPLE_NAMES]
+    return [ORDER_TYPE_MAP[name] for name in _ORDER_TYPE_EXAMPLE_NAMES]
 
 
 def get_mt5_order_type_example_names() -> list[str]:
@@ -158,7 +173,7 @@ def _validate_mt5_order_type(value: object) -> int:
     Returns:
         The validated integer ORDER_TYPE value.
     """
-    return pdmt5.parse_order_type(value)
+    return parse_order_type(value)
 
 
 Mt5Timeframe: TypeAlias = Annotated[
@@ -404,7 +419,7 @@ class TicksFromRequest(BaseModel):
         le=100000,
     )
     flags: Mt5CopyTicks = Field(
-        default=pdmt5.COPY_TICKS_MAP["COPY_TICKS_ALL"],
+        default=COPY_TICKS_MAP["COPY_TICKS_ALL"],
         description=_COPY_TICKS_DESCRIPTION,
     )
     format: ResponseFormat | None = Field(default=None)
@@ -417,7 +432,7 @@ class TicksRangeRequest(BaseModel):
     date_from: datetime = Field(..., description="Start date (ISO 8601)")
     date_to: datetime = Field(..., description="End date (ISO 8601)")
     flags: Mt5CopyTicks = Field(
-        default=pdmt5.COPY_TICKS_MAP["COPY_TICKS_ALL"],
+        default=COPY_TICKS_MAP["COPY_TICKS_ALL"],
         description=_COPY_TICKS_DESCRIPTION,
     )
     format: ResponseFormat | None = Field(default=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">= 3.11, < 3.14"
 dependencies = [
-  "pdmt5 >= 1.1.1",
+  "pdmt5 >= 1.2.0",
   "fastapi >= 0.115.0",
   "uvicorn[standard] >= 0.32.0",
   "pyarrow >= 18.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mt5api"
-version = "1.0.1"
+version = "1.0.2"
 description = "MetaTrader 5 REST API"
 authors = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]
 maintainers = [{name = "dceoy", email = "dceoy@users.noreply.github.com"}]

--- a/tests/test_pdmt5_migration.py
+++ b/tests/test_pdmt5_migration.py
@@ -1,0 +1,232 @@
+"""Regression tests for the pdmt5 >= 1.2.0 migration.
+
+pdmt5 1.2.0 removed constant-introspection helpers (``list_*``/``get_*``)
+from the package root; they remain available from ``pdmt5.constants``. These
+tests guard against regressions in that migration: import-time schema
+construction, unchanged OpenAPI schema content, unchanged parsing behavior,
+and the dependency floor declared in package metadata.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import importlib.metadata
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pdmt5
+import pytest
+from pdmt5 import constants as pdmt5_constants
+
+from mt5api import models
+from mt5api.models import (
+    CalcMarginRequest,
+    RatesFromRequest,
+    TicksFromRequest,
+)
+
+_TIMEFRAME_DESCRIPTION = (
+    "MetaTrader5 TIMEFRAME constant. Accepts a constant name such as "
+    "TIMEFRAME_M1, short aliases such as M1, or the corresponding integer value."
+)
+_COPY_TICKS_DESCRIPTION = (
+    "MetaTrader5 COPY_TICKS constant. Accepts COPY_TICKS_INFO, "
+    "COPY_TICKS_TRADE, COPY_TICKS_ALL, short aliases such as ALL, "
+    "or the corresponding integer value."
+)
+_ORDER_TYPE_DESCRIPTION = (
+    "MetaTrader5 ORDER_TYPE constant. Accepts a constant name such as "
+    "ORDER_TYPE_BUY, short aliases such as BUY, or the corresponding integer value."
+)
+
+
+def test_mt5api_models_imports_successfully() -> None:
+    """``import mt5api.models`` succeeds against the installed pdmt5."""
+    reloaded = importlib.reload(sys.modules["mt5api.models"])
+    assert reloaded is models
+
+
+def test_removed_root_helpers_are_not_exposed_by_pdmt5() -> None:
+    """pdmt5 1.2.0 no longer exposes introspection helpers at the root."""
+    removed_names = (
+        "get_timeframe_name",
+        "get_timeframe_value",
+        "get_copy_ticks_name",
+        "get_copy_ticks_value",
+        "get_order_type_name",
+        "get_order_type_value",
+        "list_timeframe_names",
+        "list_timeframe_values",
+        "list_copy_ticks_names",
+        "list_copy_ticks_values",
+        "list_order_type_names",
+        "list_order_type_values",
+    )
+    for name in removed_names:
+        assert not hasattr(pdmt5, name)
+
+
+def test_removed_root_helpers_remain_available_from_constants() -> None:
+    """The removed helpers remain public from ``pdmt5.constants``."""
+    for name in (
+        "list_timeframe_names",
+        "list_timeframe_values",
+        "list_copy_ticks_names",
+        "list_copy_ticks_values",
+        "list_order_type_names",
+        "list_order_type_values",
+    ):
+        assert callable(getattr(pdmt5_constants, name))
+
+
+def test_production_code_does_not_access_removed_pdmt5_root_helpers() -> None:
+    """No production source accesses removed helpers via ``pdmt5.<name>``."""
+    removed_prefixes = ("get_", "list_")
+    package_dir = Path(models.__file__).resolve().parent
+    for path in package_dir.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "pdmt5"
+                and node.attr.startswith(removed_prefixes)
+            ):
+                pytest.fail(f"{path}:{node.lineno} accesses pdmt5.{node.attr}")
+            if isinstance(node, ast.ImportFrom) and node.module == "pdmt5":
+                for alias in node.names:
+                    assert not alias.name.startswith(removed_prefixes), (
+                        f"{path}:{node.lineno} imports pdmt5.{alias.name}"
+                    )
+
+
+def test_timeframe_values_present_in_generated_schema() -> None:
+    """Timeframe enum values and names remain present in the schema."""
+    schema = RatesFromRequest.model_json_schema()
+    timeframe_schema = schema["properties"]["timeframe"]
+    assert timeframe_schema["description"] == _TIMEFRAME_DESCRIPTION
+    name_enum = timeframe_schema["anyOf"][0]["enum"]
+    value_enum = timeframe_schema["anyOf"][1]["enum"]
+    assert "TIMEFRAME_M1" in name_enum
+    assert "TIMEFRAME_D1" in name_enum
+    assert 1 in value_enum
+    assert 16408 in value_enum
+    assert timeframe_schema["examples"] == [
+        "TIMEFRAME_M1",
+        "TIMEFRAME_M5",
+        "TIMEFRAME_M15",
+        "TIMEFRAME_M30",
+        "TIMEFRAME_H1",
+        "TIMEFRAME_H4",
+        "TIMEFRAME_D1",
+        "TIMEFRAME_W1",
+        "TIMEFRAME_MN1",
+    ]
+
+
+def test_copy_ticks_values_present_in_generated_schema() -> None:
+    """COPY_TICKS enum values and names remain present in the schema."""
+    schema = TicksFromRequest.model_json_schema()
+    flags_schema = schema["properties"]["flags"]
+    assert flags_schema["description"] == _COPY_TICKS_DESCRIPTION
+    name_enum = flags_schema["anyOf"][0]["enum"]
+    value_enum = flags_schema["anyOf"][1]["enum"]
+    assert {"COPY_TICKS_INFO", "COPY_TICKS_TRADE", "COPY_TICKS_ALL"} <= set(name_enum)
+    assert {1, 2, -1} <= set(value_enum)
+    assert flags_schema["examples"] == [
+        "COPY_TICKS_INFO",
+        "COPY_TICKS_TRADE",
+        "COPY_TICKS_ALL",
+    ]
+
+
+def test_order_type_values_present_in_generated_schema() -> None:
+    """ORDER_TYPE enum values and names remain present in the schema."""
+    schema = CalcMarginRequest.model_json_schema()
+    action_schema = schema["properties"]["action"]
+    assert action_schema["description"] == _ORDER_TYPE_DESCRIPTION
+    name_enum = action_schema["anyOf"][0]["enum"]
+    value_enum = action_schema["anyOf"][1]["enum"]
+    assert {"ORDER_TYPE_BUY", "ORDER_TYPE_SELL"} <= set(name_enum)
+    assert {0, 1} <= set(value_enum)
+    assert action_schema["examples"] == ["ORDER_TYPE_BUY", "ORDER_TYPE_SELL"]
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected"),
+    [
+        ("M1", 1),
+        ("TIMEFRAME_M1", 1),
+        (1, 1),
+        ("D1", 16408),
+    ],
+)
+def test_timeframe_parsing_accepts_existing_aliases(
+    alias: str | int, expected: int
+) -> None:
+    """Timeframe parsing accepts the same string aliases and integers."""
+    request = RatesFromRequest.model_validate({
+        "symbol": "EURUSD",
+        "timeframe": alias,
+        "date_from": datetime(2024, 1, 1, tzinfo=UTC),
+        "count": 1,
+    })
+    assert request.timeframe == expected
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected"),
+    [
+        ("ALL", -1),
+        ("COPY_TICKS_ALL", -1),
+        (-1, -1),
+        ("INFO", 1),
+    ],
+)
+def test_copy_ticks_parsing_accepts_existing_aliases(
+    alias: str | int, expected: int
+) -> None:
+    """COPY_TICKS parsing accepts the same string aliases and integers."""
+    request = TicksFromRequest.model_validate({
+        "symbol": "EURUSD",
+        "date_from": datetime(2024, 1, 1, tzinfo=UTC),
+        "count": 1,
+        "flags": alias,
+    })
+    assert request.flags == expected
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected"),
+    [
+        ("BUY", 0),
+        ("ORDER_TYPE_BUY", 0),
+        (0, 0),
+        ("SELL", 1),
+    ],
+)
+def test_order_type_parsing_accepts_existing_aliases(
+    alias: str | int, expected: int
+) -> None:
+    """ORDER_TYPE parsing accepts the same string aliases and integers."""
+    request = CalcMarginRequest.model_validate({
+        "action": alias,
+        "symbol": "EURUSD",
+        "volume": 1.0,
+        "price": 1.1,
+    })
+    assert request.action == expected
+
+
+def test_installed_package_metadata_requires_pdmt5_1_2_0() -> None:
+    """Installed mt5api metadata declares a pdmt5 >= 1.2.0 requirement."""
+    requires = importlib.metadata.requires("mt5api") or []
+    pdmt5_requirements = [
+        req for req in requires if req.split(";")[0].strip().startswith("pdmt5")
+    ]
+    assert pdmt5_requirements, "mt5api metadata does not declare a pdmt5 requirement"
+    assert any(">=1.2.0" in req.replace(" ", "") for req in pdmt5_requirements), (
+        pdmt5_requirements
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ name = "metatrader5"
 version = "5.0.5735"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/0b/3dd5143f14319dca393a3bcf11ddf24f36f16dfb8c6d1bf2b193ce0c5733/metatrader5-5.0.5735-cp311-cp311-win_amd64.whl", hash = "sha256:0d05b69cef5eb3f43ea47cb6d36dac0e7e15f82a4fb77974439c565daa54d1c9", size = 48091, upload-time = "2026-04-04T16:44:08.677Z" },
@@ -588,7 +588,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "pdmt5", specifier = ">=1.1.1" },
+    { name = "pdmt5", specifier = ">=1.2.0" },
     { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
@@ -764,16 +764,16 @@ wheels = [
 
 [[package]]
 name = "pdmt5"
-version = "1.1.1"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "metatrader5", marker = "sys_platform == 'win32'" },
     { name = "pandas" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/9c/4c51e9b109440629762a5ca719c367798469bb590b8ce99aa0652c467549/pdmt5-1.1.1.tar.gz", hash = "sha256:2d8e4e9b87d237793f8534813b373545eadb5c0e1ced13ee8be8dc473c77190d", size = 23879, upload-time = "2026-07-07T15:50:19.604Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/44/410bdc4d567ddb49f5b8d0d366467c9cce5e1862ecfbbcd09734c8f34eac/pdmt5-1.2.0.tar.gz", hash = "sha256:972f500ee7e50032a14f83874baccbef69bf7377335011f72d0bbdd6e221edcd", size = 24017, upload-time = "2026-07-10T15:21:27.215Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/18/4221deef65dc320da9b6299e1914c36c1e81b29a5557f0c1083718b36545/pdmt5-1.1.1-py3-none-any.whl", hash = "sha256:9df16148ebec754c15ce3d1b02af82aaeec3c5cb1603a47258fa68c74f45b453", size = 22274, upload-time = "2026-07-07T15:50:18.489Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ec/88297de8aad400c922715cbdc15804dcf1ac5fbc0a3a0abeafc988c3c25d/pdmt5-1.2.0-py3-none-any.whl", hash = "sha256:ce355f24f4ec08ba5cc0148b5c529f73c671ea2e83b1d65248de1150369daeb7", size = 22369, upload-time = "2026-07-10T15:21:25.833Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -556,7 +556,7 @@ wheels = [
 
 [[package]]
 name = "mt5api"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- Bump the `pdmt5` dependency floor from `>= 1.1.1` to `>= 1.2.0` in `pyproject.toml`.
- Migrate `mt5api/models.py` off the pdmt5 package-root constant-introspection helpers (`list_timeframe_names`, `list_timeframe_values`, `list_copy_ticks_names`, `list_copy_ticks_values`, `list_order_type_names`, `list_order_type_values`), which pdmt5 1.2.0 removed from the root, importing them explicitly from `pdmt5.constants` instead. The stable root exports (`TIMEFRAME_MAP`, `COPY_TICKS_MAP`, `ORDER_TYPE_MAP`, `parse_timeframe`, `parse_copy_ticks`, `parse_order_type`) continue to come from `pdmt5`.
- Regenerated `uv.lock` via `uv lock --upgrade-package pdmt5`; it now resolves `pdmt5==1.2.0`.
- Added `tests/test_pdmt5_migration.py` with regression coverage for:
  - `import mt5api.models` succeeding against pdmt5 1.2.0,
  - the removed root helpers no longer being exposed by `pdmt5` while remaining available from `pdmt5.constants`,
  - a static-analysis check that no production source under `mt5api/` accesses removed helpers via `pdmt5.<name>`,
  - timeframe/copy-ticks/order-type enum values, descriptions, and examples remaining unchanged in generated JSON schemas,
  - existing string-alias and integer-constant parsing continuing to work,
  - installed package metadata declaring `pdmt5 >= 1.2.0`.
- A repo-wide search confirmed no other production code, tests, or docs reference the removed root helpers.

Generated OpenAPI/validation schemas, request/response models, API routes, and runtime behavior are unchanged — this is a dependency-boundary migration only.

## Test plan

- [x] `uv lock --upgrade-package pdmt5` (resolves `pdmt5==1.2.0`)
- [x] `uv sync --all-extras --dev`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest` (281 passed, 100% coverage)
- [x] `uv run python -c "import mt5api.models"`
- [x] `rg 'pdmt5\.(get_|list_)|from pdmt5 import .*?(get_|list_)' .` (no matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nUtz1bpFevaJNnsAc9Rpk

---
_Generated by [Claude Code](https://claude.ai/code/session_015nUtz1bpFevaJNnsAc9Rpk)_