### PR TITLE
Configure uv package cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ Repository = "https://github.com/dceoy/mt5api.git"
 
 [tool.uv]
 required-environments = ["platform_system == 'Windows'"]
-
+exclude-newer = "1 week"
+exclude-newer-package = { pdmt5 = false }
 [dependency-groups]
 dev = [
   "ruff >= 0.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,13 @@ required-markers = [
     "sys_platform == 'win32'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
+[options.exclude-newer-package]
+pdmt5 = false
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -131,14 +138,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -427,7 +434,7 @@ name = "metatrader5"
 version = "5.0.5735"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'win32'" },
+    { name = "numpy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/0b/3dd5143f14319dca393a3bcf11ddf24f36f16dfb8c6d1bf2b193ce0c5733/metatrader5-5.0.5735-cp311-cp311-win_amd64.whl", hash = "sha256:0d05b69cef5eb3f43ea47cb6d36dac0e7e15f82a4fb77974439c565daa54d1c9", size = 48091, upload-time = "2026-04-04T16:44:08.677Z" },


### PR DESCRIPTION
## Summary
- configure a one-week dependency cooldown in `pyproject.toml`
- preserve the Windows required-environment constraint
- exempt only `pdmt5` so its latest release can resolve immediately
- keep `pyright` and all other third-party packages subject to the cooldown
- regenerate `uv.lock` and update vulnerable `click` 8.3.1 to 8.4.2

## Configuration
```toml
[tool.uv]
required-environments = ["platform_system == 'Windows'"]
exclude-newer = "1 week"
exclude-newer-package = { pdmt5 = false }
```

## Validation
- follows uv's documented dependency-cooldown configuration
- `uv.lock` records the resolved cutoff, `P1W` span, and `pdmt5 = false`
- `pdmt5` is locked at 1.2.0
- `click` is locked at 8.4.2, fixing PYSEC-2026-2132
- the PR contains a single commit and changes only `pyproject.toml` and `uv.lock`