### PR TITLE
refactor: remove no-op startup sleep

### DIFF
--- a/mt5api/main.py
+++ b/mt5api/main.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from contextlib import asynccontextmanager
@@ -176,7 +175,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Note: MT5 client is initialized lazily on first request via dependency
     # This avoids blocking startup if MT5 is not available
-    await asyncio.sleep(0)  # Make function truly async
 
     yield
 


### PR DESCRIPTION
## Summary

- remove the unused `asyncio` import from the application entrypoint
- remove the no-op startup `await asyncio.sleep(0)`
- preserve lazy MT5 client initialization and the existing awaited shutdown cleanup

The lifespan callable remains an asynchronous generator because it yields control to the application and awaits cleanup during shutdown.

Closes #72.

## Validation

- `.agents/skills/local-qa/scripts/qa.sh`
  - Ruff format and lint
  - Pyright
  - pytest: 252 passed, 100% coverage
  - Prettier
  - Zizmor
  - Actionlint
  - Yamllint
  - Checkov
- `git diff --check`

## Runtime impact

No Windows or MetaTrader 5 behavior changes are expected. Startup still initializes the MT5 client lazily on the first request; this only removes a redundant event-loop turn.
